### PR TITLE
Add JVM Options for client connection

### DIFF
--- a/src/main/java/com/innovarhealthcare/launcher/Connection.java
+++ b/src/main/java/com/innovarhealthcare/launcher/Connection.java
@@ -18,12 +18,13 @@ public class Connection {
     private String username;
     private String password;
     private String group;
+    private String jvmOptions;
     // Constructors, getters, and setters
     public Connection() {}
 
     public Connection(String id, String name, String address, String javaHome, String javaHomeBundledValue, String javaFxHome,
                       String heapSize, String icon, boolean showJavaConsole, boolean sslProtocolsCustom, String sslProtocols,
-                      boolean sslCipherSuitesCustom, String sslCipherSuites, boolean useLegacyDHSettings, String username, String password, String group) {
+                      boolean sslCipherSuitesCustom, String sslCipherSuites, boolean useLegacyDHSettings, String username, String password, String group, String jvmOptions) {
         this.id = id;
         this.name = name;
         this.address = address;
@@ -41,6 +42,7 @@ public class Connection {
         this.username = username;
         this.password = password;
         this.group = group;
+        this.jvmOptions = jvmOptions;
     }
 
     public String getId() { return id; }
@@ -77,12 +79,12 @@ public class Connection {
     public void setUsername(String username) { this.username = username; }
     public String getPassword() { return password; }
     public void setPassword(String password) { this.password = password; }
-
     public String getGroup() {
         return group;
     }
-
     public void setGroup(String group) {
         this.group = group;
     }
+    public String getJvmOptions() { return jvmOptions; }
+    public void setJvmOptions(String jvmOptions) { this.jvmOptions = jvmOptions; }
 }

--- a/src/main/java/com/innovarhealthcare/launcher/JavaConfig.java
+++ b/src/main/java/com/innovarhealthcare/launcher/JavaConfig.java
@@ -2,13 +2,20 @@ package com.innovarhealthcare.launcher;
 
 import org.apache.commons.lang3.SystemUtils;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class JavaConfig {
     private String maxHeapSize;
     private String javaHome;
+    private String jvmOptions;
 
-    public JavaConfig(String maxHeapSize, String javaHome) {
+    public JavaConfig(String maxHeapSize, String javaHome, String jvmOptions) {
         this.maxHeapSize = maxHeapSize;
         this.javaHome = javaHome;
+        this.jvmOptions = jvmOptions;
     }
 
     public String getMaxHeapSize() {
@@ -26,6 +33,24 @@ public class JavaConfig {
     public void setJavaHome(String javaHome) {
         this.javaHome = javaHome;
     }
+
+    public String getJvmOptions() { return jvmOptions;  }
+
+    public void setJvmOptions(String jvmOptions) { this.jvmOptions = jvmOptions; }
+
+    public List<String> getJvmOptionsList() {
+        List<String> result = new ArrayList<>();
+        Matcher matcher = Pattern.compile("\"([^\"]*)\"|(\\S+)").matcher(getJvmOptions());
+        while (matcher.find()) {
+            if (matcher.group(1) != null) {
+                result.add(matcher.group(1)); // Content with spaces in ""
+            } else {
+                result.add(matcher.group(2)); // Just string without spaces
+            }
+        }
+        return result;
+    }
+
 
     public String getMaxHeapSizeBuilder(){
         return "-Xmx" + maxHeapSize;

--- a/src/main/java/com/innovarhealthcare/launcher/ProcessLauncher.java
+++ b/src/main/java/com/innovarhealthcare/launcher/ProcessLauncher.java
@@ -16,6 +16,8 @@ public class ProcessLauncher {
         List<String> command = new ArrayList<>();
         command.add(javaConfig.getJavaHomeBuilder());
         command.add(javaConfig.getMaxHeapSizeBuilder());
+        if(StringUtils.isNotBlank(javaConfig.getJvmOptions()))
+            command.addAll(javaConfig.getJvmOptionsList());
 
         if (SystemUtils.IS_OS_MAC){
             command.add("-Xdock:icon=icon.png");


### PR DESCRIPTION
A new text field has been added to the launcher configuration, allowing users to specify custom JVM options. This can be used, among other things, to change the client encoding.