### PR TITLE
Process arguments from jnlp to support server launch options

### DIFF
--- a/src/main/java/com/innovarhealthcare/launcher/CodeBase.java
+++ b/src/main/java/com/innovarhealthcare/launcher/CodeBase.java
@@ -7,12 +7,14 @@ public class CodeBase {
     private String mainClass;
     private String host;
     private String version;
+    private List<String> arguments;
 
-    public CodeBase(List<String> classpath, String mainClass, String host, String version) {
+    public CodeBase(List<String> classpath, String mainClass, String host, String version, List<String> arguments) {
         this.classpath = classpath;
         this.mainClass = mainClass;
         this.host = host;
         this.version = version;
+        this.arguments = arguments;
     }
 
     public List<String> getClasspath() {
@@ -45,5 +47,13 @@ public class CodeBase {
 
     public void setVersion(String version) {
         this.version = version;
+    }
+
+    public List<String> getArguments() {
+        return arguments;
+    }
+
+    public void setArguments(List<String> arguments) {
+        this.arguments = arguments;
     }
 }

--- a/src/main/java/com/innovarhealthcare/launcher/ProcessLauncher.java
+++ b/src/main/java/com/innovarhealthcare/launcher/ProcessLauncher.java
@@ -52,8 +52,10 @@ public class ProcessLauncher {
         command.add("-cp");
         command.add(String.join(File.pathSeparator, codeBase.getClasspath()));
         command.add(codeBase.getMainClass());
-        command.add(codeBase.getHost());
-        command.add(codeBase.getVersion());
+        
+        for(String arg : codeBase.getArguments()) {
+            command.add(arg);
+        }
 
         if(StringUtils.isNotBlank(credential.getUsername())){
             command.add(credential.getUsername());


### PR DESCRIPTION
MCAL and other launchers use the JNLP `<argument>` tag to determine launch arguments.  This allows a platform neutral way to pass launch arguments from the server to the client.  This PR updates BL Launcher to do the same.

It also processes the `main-class` attribute.