### PR TITLE
Release 1.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.innovarhealthcare</groupId>
     <artifactId>bridge-link-launcher</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/java/com/innovarhealthcare/launcher/BridgeLinkLauncher.java
+++ b/src/main/java/com/innovarhealthcare/launcher/BridgeLinkLauncher.java
@@ -24,6 +24,8 @@ import javafx.scene.control.PasswordField;
 import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.CheckBox;
+import javafx.scene.control.RadioButton;
+import javafx.scene.control.ToggleGroup;
 import javafx.scene.control.ProgressBar;
 import javafx.scene.control.ProgressIndicator;
 import javafx.scene.control.TreeCell;
@@ -83,6 +85,9 @@ public class BridgeLinkLauncher extends Application implements Progress {
     private ComboBox<BundledJava> bundledJavaCombo;
     private ComboBox<HeapMemory> heapSizeCombo;
     private TextField jvmOptionsTextField;
+    private RadioButton bundledJavaRadio;
+    private RadioButton customJavaRadio;
+    private TextField customJavaTextField;
     private CheckBox showConsoleCheckBox;
     private CheckBox clearCacheCheckBox;
     private Button iconButton;
@@ -282,6 +287,10 @@ public class BridgeLinkLauncher extends Application implements Progress {
                 heapSizeCombo.getSelectionModel().select(1);
                 jvmOptionsTextField.setText("");
                 clearCacheCheckBox.setSelected(false);
+                // Reset radio buttons to bundled and update control states
+                bundledJavaRadio.setSelected(true);
+                customJavaTextField.setText("");
+                updateJavaControlStates();
             }
 
             saveButton.setDisable(true);
@@ -292,10 +301,24 @@ public class BridgeLinkLauncher extends Application implements Progress {
             addressTextField.setDisable(!isConnection);
             usernameTextField.setDisable(!isConnection);
             passwordField.setDisable(!isConnection);
-            bundledJavaCombo.setDisable(!isConnection);
-            heapSizeCombo.setDisable(!isConnection);
             jvmOptionsTextField.setDisable(!isConnection);
             showConsoleCheckBox.setDisable(!isConnection);
+
+            // Don't directly control bundledJavaCombo and customJavaTextField here
+            // Let updateJavaControlStates() handle them based on radio button selection
+            // But disable radio buttons if no connection is selected
+            bundledJavaRadio.setDisable(!isConnection);
+            customJavaRadio.setDisable(!isConnection);
+            
+            // Only if no connection is selected, disable both Java controls
+            if (!isConnection) {
+                bundledJavaCombo.setDisable(true);
+                heapSizeCombo.setDisable(true);
+                customJavaTextField.setDisable(true);
+            } else {
+                heapSizeCombo.setDisable(false);
+                // Let updateJavaControlStates() handle bundledJavaCombo and customJavaTextField
+            }
 
             exportButton.setDisable(connectionsList.isEmpty());
         });
@@ -347,15 +370,36 @@ public class BridgeLinkLauncher extends Application implements Progress {
         HBox.setHgrow(usernameTextField, Priority.ALWAYS);
         HBox.setHgrow(passwordField, Priority.ALWAYS);
 
-        // Java Config row
-        HBox javaHeapRow = new HBox(10); // Combined Java Home and Max Heap Size
+        // Java Config rows
+        // Java Home row with radio buttons, combo box, and text field
+        HBox javaHomeRow = new HBox(10);
         Label javaHomeLabel = new Label("Java Home:");
+        ToggleGroup javaTypeGroup = new ToggleGroup();
+        bundledJavaRadio = new RadioButton("Bundled");
+        bundledJavaRadio.setToggleGroup(javaTypeGroup);
+        bundledJavaRadio.setSelected(true);
+        customJavaRadio = new RadioButton("Custom");
+        customJavaRadio.setToggleGroup(javaTypeGroup);
+        
         bundledJavaCombo = new ComboBox<>(FXCollections.observableArrayList(
                 new BundledJava("", "Java 17"),
                 new BundledJava("", "Java 8")
         ));
         bundledJavaCombo.getSelectionModel().select(0);
         bundledJavaCombo.setOnAction(e -> updateSaveButtonState());
+
+        // Custom Java text field
+        customJavaTextField = new TextField();
+        customJavaTextField.setPromptText("Enter custom Java home path (e.g., /usr/lib/jvm/java-11)");
+        customJavaTextField.setDisable(true); // Start disabled
+        customJavaTextField.textProperty().addListener((obs, oldVal, newVal) -> updateSaveButtonState());
+
+        javaHomeRow.getChildren().addAll(javaHomeLabel, bundledJavaRadio, customJavaRadio, bundledJavaCombo, customJavaTextField);
+        HBox.setHgrow(bundledJavaCombo, Priority.ALWAYS);
+        HBox.setHgrow(customJavaTextField, Priority.ALWAYS);
+
+        // Heap Size row
+        HBox heapSizeRow = new HBox(10);
         Label heapSizeLabel = new Label("Max Heap Size:");
         heapSizeCombo = new ComboBox<>(FXCollections.observableArrayList(
                 new HeapMemory("256m", "256 MB"),
@@ -366,9 +410,19 @@ public class BridgeLinkLauncher extends Application implements Progress {
         ));
         heapSizeCombo.getSelectionModel().select(1);
         heapSizeCombo.setOnAction(e -> updateSaveButtonState());
-        javaHeapRow.getChildren().addAll(javaHomeLabel, bundledJavaCombo, heapSizeLabel, heapSizeCombo);
-        HBox.setHgrow(bundledJavaCombo, Priority.ALWAYS);
+        heapSizeRow.getChildren().addAll(heapSizeLabel, heapSizeCombo);
         HBox.setHgrow(heapSizeCombo, Priority.ALWAYS);
+
+        // Radio button event handlers to enable/disable appropriate fields
+        bundledJavaRadio.setOnAction(e -> {
+            updateJavaControlStates();
+            updateSaveButtonState();
+        });
+
+        customJavaRadio.setOnAction(e -> {
+            updateJavaControlStates();
+            updateSaveButtonState();
+        });
 
         // JVM options row
         HBox jvmOptionsRow = new HBox(10);
@@ -419,7 +473,7 @@ public class BridgeLinkLauncher extends Application implements Progress {
         iconRow.getChildren().addAll(iconSelectionLabel, iconButton);
         iconRow.setAlignment(Pos.CENTER_LEFT);
 
-        configBox.getChildren().addAll(groupRow, addressRow, credentialsRow, javaHeapRow, jvmOptionsRow, consoleRow, iconRow);
+        configBox.getChildren().addAll(groupRow, addressRow, credentialsRow, javaHomeRow, heapSizeRow, jvmOptionsRow, consoleRow, iconRow);
 
         // Progress Section (unchanged)
         Separator separator = new Separator();
@@ -582,7 +636,7 @@ public class BridgeLinkLauncher extends Application implements Progress {
                 TreeItem<Connection> groupItem = groupItems.computeIfAbsent(groupName,
                         k -> {
                             Connection groupConn = new Connection(null, "", null, null, null, null, null,
-                                    null, false, false, null, false, null, false, null, null, groupName, null, false, false);
+                                    null, false, false, null, false, null, false, null, null, groupName, null, false, false, null, false);
                             TreeItem<Connection> item = new TreeItem<>(groupConn);
                             item.setExpanded(true);
                             return item;
@@ -636,7 +690,17 @@ public class BridgeLinkLauncher extends Application implements Progress {
             while (nameExists(finalName)) {
                 finalName = name + " Copy " + cnt++;
             }
-            addConnection(finalName, "", "BUNDLED", "Java 17", "", "512m", "", false, "", false, "", false, "", "", "", "", false);
+            addConnection(finalName, "", "BUNDLED", "Java 17", "", "512m", "", false, "", false, "", false, "", "", "", "", false, "", false);
+        }
+    }
+
+    private void updateJavaControlStates() {
+        if (customJavaRadio.isSelected()) {
+            bundledJavaCombo.setDisable(true);
+            customJavaTextField.setDisable(false);
+        } else {
+            bundledJavaCombo.setDisable(false);
+            customJavaTextField.setDisable(true);
         }
     }
 
@@ -656,6 +720,9 @@ public class BridgeLinkLauncher extends Application implements Progress {
                 if (newSelectedItem != null) {
                     treeSelectionModel.select(newSelectedItem);
                 }
+                
+                // Ensure the Java control states remain correct after saving
+                updateJavaControlStates();
             }
         }
     }
@@ -678,7 +745,7 @@ public class BridgeLinkLauncher extends Application implements Progress {
                     Connection newConn = new Connection(UUID.randomUUID().toString(), finalName,
                             addressTextField.getText(), getJavaHome(), bundledJavaCombo.getValue().toString(),
                             "", heapSizeCombo.getValue().toString(), "", showConsoleCheckBox.isSelected(),
-                            false, "", false, "", false, usernameTextField.getText(), passwordField.getText(), groupTextField.getText(), jvmOptionsTextField.getText(), closeWindowCheckBox.isSelected(), clearCacheCheckBox.isSelected());
+                            false, "", false, "", false, usernameTextField.getText(), passwordField.getText(), groupTextField.getText(), jvmOptionsTextField.getText(), closeWindowCheckBox.isSelected(), clearCacheCheckBox.isSelected(), customJavaTextField.getText(), customJavaRadio.isSelected());
                     connectionsList.add(newConn);
                     updateTreeView();
                     saveConnections();
@@ -765,7 +832,8 @@ public class BridgeLinkLauncher extends Application implements Progress {
                 DownloadJNLP download = new DownloadJNLP(host, cacheFolder, clearCacheCheckBox.isSelected());
                 currentDownload = download;
 
-                JavaConfig javaConfig = new JavaConfig(heapSizeCombo.getValue().toString(), this.bundledJavaCombo.getValue().toString(), this.jvmOptionsTextField.getText());
+                String customJavaHome = customJavaRadio.isSelected() ? customJavaTextField.getText() : null;
+                JavaConfig javaConfig = new JavaConfig(heapSizeCombo.getValue().toString(), this.bundledJavaCombo.getValue().toString(), this.jvmOptionsTextField.getText(), customJavaHome);
                 Credential credential = new Credential(StringUtils.trim(usernameTextField.getText()), StringUtils.trim(passwordField.getText()));
                 CodeBase codeBase = download.handle(this);
                 currentDownload = null;
@@ -971,7 +1039,6 @@ public class BridgeLinkLauncher extends Application implements Progress {
         addressTextField.setDisable(!finalEnabled);
         usernameTextField.setDisable(!finalEnabled);
         passwordField.setDisable(!finalEnabled);
-        bundledJavaCombo.setDisable(!finalEnabled);
         heapSizeCombo.setDisable(!finalEnabled);
         jvmOptionsTextField.setDisable(!finalEnabled);
         showConsoleCheckBox.setDisable(!finalEnabled);
@@ -981,6 +1048,19 @@ public class BridgeLinkLauncher extends Application implements Progress {
         duplicateButton.setDisable(!finalEnabled);
         deleteButton.setDisable(!finalEnabled);
         launchButton.setDisable(!finalEnabled);
+
+        // Handle Java controls specially - disable radio buttons if no connection selected
+        bundledJavaRadio.setDisable(!finalEnabled);
+        customJavaRadio.setDisable(!finalEnabled);
+        
+        if (!finalEnabled) {
+            // If no connection selected or launching, disable both Java controls
+            bundledJavaCombo.setDisable(true);
+            customJavaTextField.setDisable(true);
+        } else {
+            // If connection is selected and not launching, let updateJavaControlStates() handle the enables/disables
+            updateJavaControlStates();
+        }
 
         // Other UI elements only disabled during launch
         boolean launchEnabled = enabled;
@@ -1017,7 +1097,11 @@ public class BridgeLinkLauncher extends Application implements Progress {
     }
 
     private String getJavaHome() {
-        return "BUNDLED";
+        if (customJavaRadio != null && customJavaRadio.isSelected()) {
+            return "CUSTOM";
+        } else {
+            return "BUNDLED";
+        }
     }
 
     private List<Connection> loadConnections() {
@@ -1058,11 +1142,11 @@ public class BridgeLinkLauncher extends Application implements Progress {
     private void addConnection(String name, String address, String javaHome, String javaHomeBundledValue,
                                String javaFxHome, String heapSize, String icon, boolean showJavaConsole,
                                String sslProtocols, boolean sslProtocolsCustom, String sslCipherSuites,
-                               boolean useLegacyDHSettings, String username, String password, String group, String jvmOptions, boolean closeWindow) {
+                               boolean useLegacyDHSettings, String username, String password, String group, String jvmOptions, boolean closeWindow, String customJavaHome, boolean useCustomJavaHome) {
         Connection conn = new Connection(UUID.randomUUID().toString(), name, address, javaHome,
                 javaHomeBundledValue, javaFxHome, heapSize, icon, showJavaConsole,
                 sslProtocolsCustom, sslProtocols, false, sslCipherSuites, useLegacyDHSettings,
-                username, password, group, jvmOptions, closeWindow, false);
+                username, password, group, jvmOptions, closeWindow, false, customJavaHome, useCustomJavaHome);
         this.connectionsList.add(conn);
         updateTreeView(); // Update tree after adding
         saveConnections();
@@ -1096,6 +1180,20 @@ public class BridgeLinkLauncher extends Application implements Progress {
         closeWindowCheckBox.setSelected(conn.isCloseWindow());
         clearCacheCheckBox.setSelected(conn.isClearCacheJars());
 
+        // Handle custom Java home setting
+        String customJavaHome = conn.getCustomJavaHome();
+        customJavaTextField.setText(customJavaHome != null ? customJavaHome : "");
+        
+        // Set radio button based on stored preference
+        if (conn.isUseCustomJavaHome()) {
+            customJavaRadio.setSelected(true);
+        } else {
+            bundledJavaRadio.setSelected(true);
+        }
+
+        // Ensure control states are properly set
+        updateJavaControlStates();
+
         // Update icon UI - use tempSelectedIcon if set, otherwise use connection's icon
         String iconToDisplay = (tempSelectedIcon != null) ? tempSelectedIcon : conn.getIcon();
         updateIconButton(iconToDisplay);
@@ -1128,6 +1226,17 @@ public class BridgeLinkLauncher extends Application implements Progress {
         conn.setUseLegacyDHSettings(false);
         conn.setCloseWindow(this.closeWindowCheckBox.isSelected());
         conn.setClearCacheJars(this.clearCacheCheckBox.isSelected());
+
+        // Always save custom Java home value if it exists, regardless of radio selection
+        String customJavaPath = customJavaTextField.getText().trim();
+        if (!customJavaPath.isEmpty()) {
+            conn.setCustomJavaHome(customJavaPath);
+        } else {
+            conn.setCustomJavaHome(null);
+        }
+        
+        // Save the radio button selection state
+        conn.setUseCustomJavaHome(customJavaRadio.isSelected());
     }
 
     private void updateSaveButtonState() {
@@ -1162,6 +1271,8 @@ public class BridgeLinkLauncher extends Application implements Progress {
                 StringUtils.equals(selected.getPassword(), this.passwordField.getText()) &&
                 StringUtils.equals(selected.getJavaHome(), getJavaHome()) &&
                 StringUtils.equals(selected.getJavaHomeBundledValue(), this.bundledJavaCombo.getValue().toString()) &&
+                StringUtils.equals(selected.getCustomJavaHome(), this.customJavaTextField.getText()) &&
+                selected.isUseCustomJavaHome() == customJavaRadio.isSelected() &&
                 StringUtils.equals(selected.getHeapSize(), this.heapSizeCombo.getValue().toString()) &&
                 StringUtils.equals(selected.getJvmOptions(), this.jvmOptionsTextField.getText()) &&
                 selected.isShowJavaConsole() == showConsoleCheckBox.isSelected() &&

--- a/src/main/java/com/innovarhealthcare/launcher/BridgeLinkLauncher.java
+++ b/src/main/java/com/innovarhealthcare/launcher/BridgeLinkLauncher.java
@@ -961,25 +961,48 @@ public class BridgeLinkLauncher extends Application implements Progress {
         }
     }
 
-    // New method to export selected connection
     private void exportConnections() {
         if (isLaunching || connectionsList.isEmpty()) return;
 
+        ExportOptionsDialog exportDialog = new ExportOptionsDialog(primaryStage, LAUNCHER_ICON);
+        if (!exportDialog.showAndWait()) return;
+
         FileChooser fileChooser = new FileChooser();
-        fileChooser.setTitle("Export All Connections");
+        fileChooser.setTitle("Export Connections");
         fileChooser.getExtensionFilters().add(
                 new FileChooser.ExtensionFilter("JSON Files", "*.json")
         );
-        fileChooser.setInitialFileName("all_connections.json"); // Default name for all connections
+        fileChooser.setInitialFileName("all_connections.json");
         File file = fileChooser.showSaveDialog(primaryStage);
 
         if (file != null) {
-            try {
-                ObjectMapper objectMapper = new ObjectMapper();
-                objectMapper.writeValue(file, connectionsList); // Export entire list
-            } catch (IOException e) {
-                showAlert("Failed to export connections: " + e.getMessage());
+            writeConnectionsToFile(file, exportDialog.isExportWithCredential());
+        }
+    }
+
+    private void writeConnectionsToFile(File file, boolean withCredential) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            if (!withCredential) {
+                List<Connection> sanitized = new ArrayList<>();
+                for (Connection conn : connectionsList) {
+                    Connection copy = new Connection(
+                            conn.getId(), conn.getName(), conn.getAddress(),
+                            conn.getJavaHome(), conn.getJavaHomeBundledValue(), conn.getJavaFxHome(),
+                            conn.getHeapSize(), conn.getIcon(), conn.isShowJavaConsole(),
+                            conn.isSslProtocolsCustom(), conn.getSslProtocols(),
+                            conn.isSslCipherSuitesCustom(), conn.getSslCipherSuites(),
+                            conn.isUseLegacyDHSettings(), "", "",
+                            conn.getGroup(), conn.getJvmOptions(), conn.isCloseWindow(),
+                            conn.isClearCacheJars(), conn.getCustomJavaHome(), conn.isUseCustomJavaHome());
+                    sanitized.add(copy);
+                }
+                objectMapper.writeValue(file, sanitized);
+            } else {
+                objectMapper.writeValue(file, connectionsList);
             }
+        } catch (IOException e) {
+            showAlert("Failed to export connections: " + e.getMessage());
         }
     }
 

--- a/src/main/java/com/innovarhealthcare/launcher/Connection.java
+++ b/src/main/java/com/innovarhealthcare/launcher/Connection.java
@@ -21,12 +21,14 @@ public class Connection {
     private String jvmOptions;
     private boolean closeWindow;
     private boolean clearCacheJars;
+    private String customJavaHome;  // New field for custom Java home path
+    private boolean useCustomJavaHome; // New field to track if custom Java home radio is selected
     // Constructors, getters, and setters
     public Connection() {}
 
     public Connection(String id, String name, String address, String javaHome, String javaHomeBundledValue, String javaFxHome,
                       String heapSize, String icon, boolean showJavaConsole, boolean sslProtocolsCustom, String sslProtocols,
-                      boolean sslCipherSuitesCustom, String sslCipherSuites, boolean useLegacyDHSettings, String username, String password, String group, String jvmOptions, boolean closeWindow, boolean clearCacheJars) {
+                      boolean sslCipherSuitesCustom, String sslCipherSuites, boolean useLegacyDHSettings, String username, String password, String group, String jvmOptions, boolean closeWindow, boolean clearCacheJars, String customJavaHome, boolean useCustomJavaHome) {
         this.id = id;
         this.name = name;
         this.address = address;
@@ -47,6 +49,8 @@ public class Connection {
         this.jvmOptions = jvmOptions;
         this.closeWindow = closeWindow;
         this.clearCacheJars = clearCacheJars;
+        this.customJavaHome = customJavaHome;
+        this.useCustomJavaHome = useCustomJavaHome;
     }
 
     public String getId() { return id; }
@@ -95,4 +99,8 @@ public class Connection {
     public void setCloseWindow(boolean closeWindow) { this.closeWindow = closeWindow; }
     public boolean isClearCacheJars() { return clearCacheJars; }
     public void setClearCacheJars(boolean clearCacheJars) { this.clearCacheJars = clearCacheJars; }
+    public String getCustomJavaHome() { return customJavaHome; }
+    public void setCustomJavaHome(String customJavaHome) { this.customJavaHome = customJavaHome; }
+    public boolean isUseCustomJavaHome() { return useCustomJavaHome; }
+    public void setUseCustomJavaHome(boolean useCustomJavaHome) { this.useCustomJavaHome = useCustomJavaHome; }
 }

--- a/src/main/java/com/innovarhealthcare/launcher/ExportOptionsDialog.java
+++ b/src/main/java/com/innovarhealthcare/launcher/ExportOptionsDialog.java
@@ -1,0 +1,87 @@
+package com.innovarhealthcare.launcher;
+
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.Label;
+import javafx.scene.image.Image;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+
+/**
+ * Dialog for selecting export options when exporting connections.
+ *
+ * @author thait
+ */
+public class ExportOptionsDialog {
+
+    private final Stage parentStage;
+    private final Image icon;
+    private boolean exportWithCredential = false;
+    private boolean confirmed = false;
+
+    public ExportOptionsDialog(Stage parentStage, Image icon) {
+        this.parentStage = parentStage;
+        this.icon = icon;
+    }
+
+    /**
+     * Shows the dialog and blocks until it is closed.
+     *
+     * @return true if the user clicked OK, false if cancelled
+     */
+    public boolean showAndWait() {
+        Stage dialogStage = new Stage();
+        dialogStage.setTitle("Export Connections");
+        dialogStage.initOwner(parentStage);
+        dialogStage.initModality(Modality.APPLICATION_MODAL);
+        dialogStage.setResizable(false);
+        if (icon != null) {
+            dialogStage.getIcons().add(icon);
+        }
+
+        VBox root = new VBox(12);
+        root.setPadding(new Insets(15));
+
+        Label promptLabel = new Label("Export options:");
+
+        CheckBox credentialCheckBox = new CheckBox("Export connections without user credentials");
+        credentialCheckBox.setSelected(true); // default: strip credentials
+
+        HBox buttonBox = new HBox(10);
+        buttonBox.setAlignment(Pos.CENTER_RIGHT);
+
+        Button okButton = new Button("OK");
+        okButton.setDefaultButton(true);
+        okButton.setOnAction(e -> {
+            exportWithCredential = !credentialCheckBox.isSelected();
+            confirmed = true;
+            dialogStage.close();
+        });
+
+        Button cancelButton = new Button("Cancel");
+        cancelButton.setCancelButton(true);
+        cancelButton.setOnAction(e -> dialogStage.close());
+
+        buttonBox.getChildren().addAll(okButton, cancelButton);
+        root.getChildren().addAll(promptLabel, credentialCheckBox, buttonBox);
+
+        Scene scene = new Scene(root, 360, 120);
+        dialogStage.setScene(scene);
+        dialogStage.showAndWait();
+
+        return confirmed;
+    }
+
+    public boolean isExportWithCredential() {
+        return exportWithCredential;
+    }
+
+    public void setExportWithCredential(boolean exportWithCredential) {
+        this.exportWithCredential = exportWithCredential;
+    }
+}

--- a/src/main/java/com/innovarhealthcare/launcher/ExportOptionsDialog.java
+++ b/src/main/java/com/innovarhealthcare/launcher/ExportOptionsDialog.java
@@ -49,8 +49,8 @@ public class ExportOptionsDialog {
 
         Label promptLabel = new Label("Export options:");
 
-        CheckBox credentialCheckBox = new CheckBox("Export connections without user credentials");
-        credentialCheckBox.setSelected(true); // default: strip credentials
+        CheckBox credentialCheckBox = new CheckBox("Include user credentials");
+        credentialCheckBox.setSelected(false); // default: strip credentials
 
         HBox buttonBox = new HBox(10);
         buttonBox.setAlignment(Pos.CENTER_RIGHT);
@@ -58,7 +58,7 @@ public class ExportOptionsDialog {
         Button okButton = new Button("OK");
         okButton.setDefaultButton(true);
         okButton.setOnAction(e -> {
-            exportWithCredential = !credentialCheckBox.isSelected();
+            exportWithCredential = credentialCheckBox.isSelected();
             confirmed = true;
             dialogStage.close();
         });

--- a/src/main/java/com/innovarhealthcare/launcher/JavaConfig.java
+++ b/src/main/java/com/innovarhealthcare/launcher/JavaConfig.java
@@ -15,11 +15,20 @@ public class JavaConfig {
     private String maxHeapSize;
     private String javaHome;
     private String jvmOptions;
+    private String customJavaHome; // Custom Java home path
 
     public JavaConfig(String maxHeapSize, String javaHome, String jvmOptions) {
         this.maxHeapSize = maxHeapSize;
         this.javaHome = javaHome;
         this.jvmOptions = jvmOptions;
+        this.customJavaHome = null;
+    }
+
+    public JavaConfig(String maxHeapSize, String javaHome, String jvmOptions, String customJavaHome) {
+        this.maxHeapSize = maxHeapSize;
+        this.javaHome = javaHome;
+        this.jvmOptions = jvmOptions;
+        this.customJavaHome = customJavaHome;
     }
 
     public String getMaxHeapSize() {
@@ -65,6 +74,16 @@ public class JavaConfig {
         final boolean mac = SystemUtils.IS_OS_MAC;
         final String exe = win ? "java.exe" : "java";
 
+        // First priority: use custom Java home if specified
+        if (customJavaHome != null && !customJavaHome.isEmpty()) {
+            Path customPath = Paths.get(customJavaHome, "bin", exe);
+            if (Files.isExecutable(customPath)) {
+                return customPath.toString();
+            }
+            // If custom path doesn't work, log warning and fall through to bundled
+            System.err.println("Warning: Custom Java home not executable: " + customPath);
+        }
+
         // Choose the expected bundled layout
         Path candidate;
         if ("Java 17".equals(javaHome)) {
@@ -102,6 +121,14 @@ public class JavaConfig {
 
         // Fallback 3: rely on PATH
         return exe;
+    }
+
+    public String getCustomJavaHome() {
+        return customJavaHome;
+    }
+
+    public void setCustomJavaHome(String customJavaHome) {
+        this.customJavaHome = customJavaHome;
     }
 
 }


### PR DESCRIPTION
## Summary

- Custom JRE / bundled Java support (Java 17, Java 21)
- Custom Java home path selection per connection
- Icon selection dialog for connections
- Export connections without user credentials
- Process arguments from JNLP to support server launch options
- Various bug fixes (close-after-launch, server version display, argument handling)
- Bump version to 1.3.0

## Test plan

- [ ] Launch against a Mirth Connect server using bundled Java
- [ ] Launch against a Mirth Connect server using a custom Java home
- [ ] Verify icon selection saves and persists per connection
- [ ] Export connections and confirm credentials are excluded
- [ ] Verify close-after-launch behavior works correctly
- [ ] Verify server arguments are passed correctly on launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)