### PR TITLE
fix: stop Windows eating quotes in launched arguments (BridgeLink#165)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,8 @@
 
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <jackson-databind.version>2.13.3</jackson-databind.version>
+        <junit.version>4.13.2</junit.version>
+        <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
     </properties>
 
     <dependencies>
@@ -28,6 +30,12 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-databind.version}</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -39,6 +47,12 @@
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
             </plugin>
 
             <plugin>

--- a/src/main/java/com/innovarhealthcare/launcher/ProcessLauncher.java
+++ b/src/main/java/com/innovarhealthcare/launcher/ProcessLauncher.java
@@ -134,6 +134,8 @@ public class ProcessLauncher {
             command.add(credential.getPassword());
         }
 
+        protectArguments(command);
+
         log("🔍 FINAL COMMAND ANALYSIS:");
         log("📏 Total command parts: " + command.size());
         for (int i = 0; i < command.size(); i++) {
@@ -192,7 +194,9 @@ public class ProcessLauncher {
             consoleCommand.add("-cp");
             consoleCommand.add("lib/java-console.jar");
             consoleCommand.add("com.innovarhealthcare.launcher.JavaConsoleDialog");
-            
+
+            protectArguments(consoleCommand);
+
             ProcessBuilder consolePb = new ProcessBuilder(consoleCommand);
 
             // Start Console Process
@@ -249,6 +253,20 @@ public class ProcessLauncher {
         log("⏰ Check the dock/taskbar now to see if the tooltip shows 'BridgeLink Administrator'");
     }
     
+    /**
+     * Windows rebuilds the argument list into a single command line, which silently eats any quote
+     * inside an argument - a saved password of {@code pa"ss} reaches the Administrator as
+     * {@code pass} (issue #165). Rewrite the affected arguments so they survive that round trip.
+     *
+     * <p>Index 0 is skipped: {@code ProcessImpl} resolves the executable path itself and pre-quoting
+     * it would break that lookup.
+     */
+    private void protectArguments(List<String> command) {
+        for (int i = 1; i < command.size(); i++) {
+            command.set(i, WindowsArguments.protect(command.get(i)));
+        }
+    }
+
     private String getProcessId(Process process) {
         try {
             // Try to get PID using reflection for Java 9+

--- a/src/main/java/com/innovarhealthcare/launcher/ProcessLauncher.java
+++ b/src/main/java/com/innovarhealthcare/launcher/ProcessLauncher.java
@@ -18,6 +18,7 @@ import java.util.List;
 public class ProcessLauncher {
     private static final String LOG_FILE = "process-launcher-debug.log";
     private static final boolean DEBUG = false;
+    private static final String REDACTED = "********";
     
     // Overloaded method for backward compatibility
     public void launch(JavaConfig javaConfig, Credential credential, CodeBase codeBase, boolean isShowConsole) throws Exception {
@@ -130,16 +131,24 @@ public class ProcessLauncher {
             command.add(credential.getUsername());
         }
 
+        int passwordIndex = -1;
         if(StringUtils.isNotBlank(credential.getPassword())){
+            passwordIndex = command.size();
             command.add(credential.getPassword());
         }
 
         protectArguments(command);
 
+        // Never let the password reach stdout or the log file.
+        List<String> loggableCommand = new ArrayList<>(command);
+        if (passwordIndex >= 0) {
+            loggableCommand.set(passwordIndex, REDACTED);
+        }
+
         log("🔍 FINAL COMMAND ANALYSIS:");
-        log("📏 Total command parts: " + command.size());
-        for (int i = 0; i < command.size(); i++) {
-            String part = command.get(i);
+        log("📏 Total command parts: " + loggableCommand.size());
+        for (int i = 0; i < loggableCommand.size(); i++) {
+            String part = loggableCommand.get(i);
             if (part.startsWith("-Xdock:") || part.startsWith("-Dapp.") || part.startsWith("-Dapple.awt.") || part.startsWith("-Dcom.apple.")) {
                 log("   [" + i + "] 🎯 " + part + " ← IMPORTANT FOR DOCK/TASKBAR");
             } else {
@@ -152,7 +161,7 @@ public class ProcessLauncher {
 
         log("🚀 Starting process...");
         // Debug: Print the command being executed (useful for troubleshooting)
-        System.out.println("DEBUG: Executing command: " + String.join(" ", command));
+        System.out.println("DEBUG: Executing command: " + String.join(" ", loggableCommand));
 
         Process targetProcess;
         if(isShowConsole) {

--- a/src/main/java/com/innovarhealthcare/launcher/WindowsArguments.java
+++ b/src/main/java/com/innovarhealthcare/launcher/WindowsArguments.java
@@ -1,0 +1,108 @@
+package com.innovarhealthcare.launcher;
+
+import org.apache.commons.lang3.SystemUtils;
+
+/**
+ * Keeps command line arguments intact on Windows.
+ *
+ * <p>Windows has no argv. {@link ProcessBuilder} hands the OS a single command line string, and
+ * {@code java.lang.ProcessImpl} is what turns the argument list back into that string. In its
+ * default ("legacy") mode ProcessImpl only wraps an argument in quotes when it contains a space or
+ * a tab, and it never escapes a quote <em>inside</em> an argument. The child then splits the
+ * command line again and the quote is consumed: a password of {@code pa"ss} arrives as
+ * {@code pass}, and {@code "secret"} arrives as {@code secret}.
+ *
+ * <p>That is BridgeLink issue #165 - a saved password containing {@code "} is not forwarded to the
+ * Administrator login.
+ *
+ * <p>The fix is to quote the argument ourselves using the algorithm {@code CommandLineToArgvW}
+ * uses to split a command line, because ProcessImpl leaves an argument alone when it already starts
+ * and ends with a quote. The pre-quoted form therefore reaches the child verbatim and unwinds back
+ * to the original text.
+ *
+ * <p>Only arguments that actually contain a quote are rewritten. Backslashes, spaces, and the shell
+ * metacharacters {@code & | ^ < >} already survive ProcessImpl unharmed, so leaving them untouched
+ * keeps this change to the one case that is broken.
+ */
+public final class WindowsArguments {
+
+    private static final char QUOTE = '"';
+    private static final char BACKSLASH = '\\';
+
+    private WindowsArguments() {}
+
+    /**
+     * Returns {@code arg} in a form that reaches the child process unchanged.
+     *
+     * <p>A no-op off Windows (where the argument vector is passed through as-is) and a no-op for
+     * arguments that contain no quote.
+     */
+    public static String protect(String arg) {
+        if (arg == null || arg.indexOf(QUOTE) < 0) {
+            return arg;
+        }
+        if (!SystemUtils.IS_OS_WINDOWS) {
+            return arg;
+        }
+        if (!isLegacyQuotingActive()) {
+            /*
+             * ProcessImpl is in VERIFICATION_WIN32_SAFE mode and escapes interior quotes itself.
+             * Pre-quoting on top of that is rejected outright ("Malformed argument has embedded
+             * quote"), so hand the argument over untouched.
+             */
+            return arg;
+        }
+        return quote(arg);
+    }
+
+    /**
+     * Applies {@code CommandLineToArgvW} quoting: the result always starts and ends with a quote,
+     * every interior quote is escaped with a backslash, and every backslash that ends up in front
+     * of a quote is doubled so it is read as a literal backslash rather than an escape.
+     */
+    static String quote(String arg) {
+        StringBuilder quoted = new StringBuilder(arg.length() + 8);
+        quoted.append(QUOTE);
+
+        int pendingBackslashes = 0;
+        for (int i = 0; i < arg.length(); i++) {
+            char c = arg.charAt(i);
+            if (c == BACKSLASH) {
+                // Held back: whether these need doubling depends on what follows them.
+                pendingBackslashes++;
+            } else if (c == QUOTE) {
+                appendBackslashes(quoted, pendingBackslashes * 2 + 1);
+                pendingBackslashes = 0;
+                quoted.append(QUOTE);
+            } else {
+                appendBackslashes(quoted, pendingBackslashes);
+                pendingBackslashes = 0;
+                quoted.append(c);
+            }
+        }
+
+        // Backslashes immediately before the closing quote would otherwise escape it.
+        appendBackslashes(quoted, pendingBackslashes * 2);
+        quoted.append(QUOTE);
+        return quoted.toString();
+    }
+
+    /**
+     * Whether {@code ProcessImpl} will pass an already-quoted argument through verbatim, which is
+     * what {@link #quote(String)} relies on. True unless the JVM was started with
+     * {@code -Djdk.lang.Process.allowAmbiguousCommands=false} or runs under a security manager.
+     */
+    @SuppressWarnings({ "deprecation", "removal" })
+    static boolean isLegacyQuotingActive() {
+        if (System.getSecurityManager() != null) {
+            return false;
+        }
+        return !"false".equalsIgnoreCase(System.getProperty("jdk.lang.Process.allowAmbiguousCommands", "true"));
+    }
+
+    private static void appendBackslashes(StringBuilder sb, int count) {
+        for (int i = 0; i < count; i++) {
+            sb.append(BACKSLASH);
+        }
+    }
+}

--- a/src/test/java/com/innovarhealthcare/launcher/ArgumentEchoMain.java
+++ b/src/test/java/com/innovarhealthcare/launcher/ArgumentEchoMain.java
@@ -1,0 +1,17 @@
+package com.innovarhealthcare.launcher;
+
+/**
+ * Child process used by {@link WindowsArgumentsTest} to report the arguments it actually received.
+ * Each argument is printed on its own line, wrapped in markers so trailing whitespace survives.
+ */
+public class ArgumentEchoMain {
+
+    public static final String PREFIX = "<<<";
+    public static final String SUFFIX = ">>>";
+
+    public static void main(String[] args) {
+        for (String arg : args) {
+            System.out.println(PREFIX + arg + SUFFIX);
+        }
+    }
+}

--- a/src/test/java/com/innovarhealthcare/launcher/WindowsArgumentsTest.java
+++ b/src/test/java/com/innovarhealthcare/launcher/WindowsArgumentsTest.java
@@ -1,0 +1,155 @@
+package com.innovarhealthcare.launcher;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class WindowsArgumentsTest {
+
+    /** The cases from issue #165, plus the neighbouring characters that must not regress. */
+    private static final String[] PASSWORDS = {
+            "simple123",
+            "pa\"ss",             // interior quote - the reported bug
+            "\"quoted\"",         // leading and trailing quote
+            "pa ss\"word",        // space and quote
+            "tri\"p\"le\"quote",
+            "back\\slash",
+            "esc\\\"quote",       // backslash immediately before a quote
+            "two\\\\\"quotes",
+            "tail\\",
+            "amp&pipe|caret^",
+            "lt<gt>",
+            "sp ace",
+            "per%cent%",
+            "P@ssw0rd!\"#$"
+    };
+
+    // --- quoting algorithm -------------------------------------------------
+
+    @Test
+    public void quoteWrapsAndEscapesInteriorQuotes() {
+        assertEquals("\"pa\\\"ss\"", WindowsArguments.quote("pa\"ss"));
+        assertEquals("\"\\\"quoted\\\"\"", WindowsArguments.quote("\"quoted\""));
+        assertEquals("\"plain\"", WindowsArguments.quote("plain"));
+    }
+
+    @Test
+    public void quoteDoublesBackslashesThatPrecedeAQuote() {
+        // one backslash before a quote becomes two, so it reads as a literal backslash
+        assertEquals("\"esc\\\\\\\"quote\"", WindowsArguments.quote("esc\\\"quote"));
+        // backslashes not in front of a quote are left alone
+        assertEquals("\"back\\slash\"", WindowsArguments.quote("back\\slash"));
+    }
+
+    @Test
+    public void quoteDoublesTrailingBackslashesSoTheyDoNotEscapeTheClosingQuote() {
+        assertEquals("\"tail\\\\\"", WindowsArguments.quote("tail\\"));
+        assertEquals("\"tail\\\\\\\\\"", WindowsArguments.quote("tail\\\\"));
+    }
+
+    // --- protect() gating --------------------------------------------------
+
+    @Test
+    public void protectLeavesArgumentsWithoutQuotesAlone() {
+        assertEquals("sp ace", WindowsArguments.protect("sp ace"));
+        assertEquals("back\\slash", WindowsArguments.protect("back\\slash"));
+        assertEquals("amp&pipe|caret^", WindowsArguments.protect("amp&pipe|caret^"));
+        assertEquals(null, WindowsArguments.protect(null));
+        assertEquals("", WindowsArguments.protect(""));
+    }
+
+    @Test
+    public void protectRewritesQuotedArgumentsOnWindowsOnly() {
+        String protectedArg = WindowsArguments.protect("pa\"ss");
+        if (SystemUtils.IS_OS_WINDOWS && WindowsArguments.isLegacyQuotingActive()) {
+            assertEquals("\"pa\\\"ss\"", protectedArg);
+        } else {
+            assertEquals("pa\"ss", protectedArg);
+        }
+    }
+
+    @Test
+    public void protectStandsDownWhenProcessImplDoesTheEscapingItself() {
+        String previous = System.getProperty("jdk.lang.Process.allowAmbiguousCommands");
+        System.setProperty("jdk.lang.Process.allowAmbiguousCommands", "false");
+        try {
+            assertEquals("pa\"ss", WindowsArguments.protect("pa\"ss"));
+        } finally {
+            if (previous == null) {
+                System.clearProperty("jdk.lang.Process.allowAmbiguousCommands");
+            } else {
+                System.setProperty("jdk.lang.Process.allowAmbiguousCommands", previous);
+            }
+        }
+    }
+
+    // --- the real thing: does the child actually receive the password? -----
+
+    /**
+     * Spawns a JVM the same way {@code ProcessLauncher} does and checks every password arrives
+     * byte-for-byte. Windows only - everywhere else the argument vector is passed straight through
+     * and there is nothing to verify.
+     */
+    @Test
+    public void passwordsSurviveARealProcessLaunch() throws Exception {
+        Assume.assumeTrue("Windows-only: elsewhere argv is passed through as-is", SystemUtils.IS_OS_WINDOWS);
+
+        List<String> mangled = new ArrayList<String>();
+        for (String password : PASSWORDS) {
+            String received = launchAndEcho("someuser", password);
+            if (!password.equals(received)) {
+                mangled.add("sent <" + password + "> but child got <" + received + ">");
+            }
+        }
+        assertTrue("Arguments were mangled on the way to the child process: " + mangled, mangled.isEmpty());
+    }
+
+    private String launchAndEcho(String username, String password) throws Exception {
+        List<String> command = new ArrayList<String>();
+        command.add(System.getProperty("java.home") + File.separator + "bin" + File.separator + "java");
+        command.add("-cp");
+        command.add(testClassesDirectory());
+        command.add(ArgumentEchoMain.class.getName());
+        command.add(username);
+        command.add(password);
+
+        // Exactly what ProcessLauncher does before handing the list to ProcessBuilder.
+        for (int i = 1; i < command.size(); i++) {
+            command.set(i, WindowsArguments.protect(command.get(i)));
+        }
+
+        ProcessBuilder pb = new ProcessBuilder(command);
+        pb.redirectErrorStream(true);
+        Process process = pb.start();
+
+        List<String> echoed = new ArrayList<String>();
+        BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+        try {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.startsWith(ArgumentEchoMain.PREFIX) && line.endsWith(ArgumentEchoMain.SUFFIX)) {
+                    echoed.add(line.substring(ArgumentEchoMain.PREFIX.length(),
+                            line.length() - ArgumentEchoMain.SUFFIX.length()));
+                }
+            }
+        } finally {
+            reader.close();
+        }
+        process.waitFor();
+
+        return echoed.size() == 2 ? echoed.get(1) : "<child echoed " + echoed.size() + " argument(s): " + echoed + ">";
+    }
+
+    private String testClassesDirectory() throws Exception {
+        return new File(ArgumentEchoMain.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getAbsolutePath();
+    }
+}

--- a/src/test/java/com/innovarhealthcare/launcher/WindowsArgumentsTest.java
+++ b/src/test/java/com/innovarhealthcare/launcher/WindowsArgumentsTest.java
@@ -115,7 +115,9 @@ public class WindowsArgumentsTest {
 
     private String launchAndEcho(String username, String password) throws Exception {
         List<String> command = new ArrayList<String>();
-        command.add(System.getProperty("java.home") + File.separator + "bin" + File.separator + "java");
+        // "java.exe", matching JavaConfig#getJavaHomeBuilder - this test is Windows-only, and
+        // relying on CreateProcess to infer the extension would not mirror the production launch.
+        command.add(System.getProperty("java.home") + File.separator + "bin" + File.separator + "java.exe");
         command.add("-cp");
         command.add(testClassesDirectory());
         command.add(ArgumentEchoMain.class.getName());


### PR DESCRIPTION
Fixes #33 (originally reported as Innovar-Healthcare/BridgeLink#165).

## The bug

A saved password containing a double quote is not forwarded to the Administrator login. `pa"ss` arrives as `pass`, and a password that both starts and ends with a quote — `"secret"` — arrives as `secret`.

The issue was filed against the BridgeLink engine, but nothing there is at fault: `Mirth.main` reads `args[3]` correctly. The corruption happens here, in the launcher.

## Why it happens

Windows has no argv. `ProcessBuilder` hands the OS a single command line string, and `java.lang.ProcessImpl` is what turns the argument list back into that string. In its default "legacy" mode it only wraps an argument in quotes when it contains a space or a tab, and it never escapes a quote *inside* an argument. The child then splits the command line again and the quote is consumed.

`ProcessLauncher` appends the password straight onto that list, so any quote in it is silently eaten before the Administrator ever sees it.

## The fix

`WindowsArguments.protect()` pre-quotes affected arguments using the algorithm `CommandLineToArgvW` uses to split a command line. `ProcessImpl` passes an argument through verbatim once it already starts and ends with a quote, so the pre-quoted form survives and unwinds back to the original text.

Scope is deliberately narrow:

- only arguments that actually contain a quote are rewritten — backslashes, spaces and `& | ^ < >` already round trip intact, and are left alone;
- only on Windows — everywhere else the argument vector is passed through as-is;
- index 0 is skipped, because `ProcessImpl` resolves the executable path itself and pre-quoting it would break that lookup.

### Why not the one-line alternative

`-Djdk.lang.Process.allowAmbiguousCommands=false` switches `ProcessImpl` into a mode that escapes interior quotes itself. It is not enough, and the two approaches cannot be combined:

| password | today | `allowAmbiguousCommands=false` | this PR |
|---|---|---|---|
| `pa"ss` | `pass` ❌ | `pa"ss` ✅ | ✅ |
| `"quoted"` | `quoted` ❌ | `quoted` ❌ | ✅ |
| `pa ss"word` | `pa ssword` ❌ | ✅ | ✅ |

It also rejects the pre-quoted form outright with `IOException: Malformed argument has embedded quote`, so `protect()` detects that mode and stands down rather than fighting it.

## Notes on the test code

This PR adds JUnit 4 and a pinned surefire to a project that has not had a test phase before. That is a deliberate choice rather than scope creep, and reviewers should weigh it:

- **The quoting rule cannot be verified by reading it.** Whether a given string survives `ProcessBuilder` on Windows depends on `ProcessImpl` internals interacting with the child's command line parsing. The only honest check is to launch a real process and ask what it received, which is what `passwordsSurviveARealProcessLaunch` does — it spawns a JVM for 14 password shapes and asserts each arrives byte-for-byte.
- **The suite has been seen to fail.** Neutering `protect()` back to `return arg;` makes it report exactly the 7 shapes that are broken today: `pa"ss`, `"quoted"`, `pa ss"word`, `tri"p"le"quote`, `esc\"quote`, `two\\"quotes`, `P@ssw0rd!"#$`. A test that has only ever passed proves nothing, so this was checked explicitly.
- **The launch test is Windows-only** and uses `Assume.assumeTrue`, so it skips cleanly on Linux and macOS rather than failing.
- **`ArgumentEchoMain`** is a test fixture, not production code — it is the child process that reports its own arguments back.
- **CI will not run these.** The existing workflow is release-triggered on Temurin 8, which has no JavaFX and so cannot compile the main sources at all. That is pre-existing and out of scope here, but it does mean the suite is currently a local gate. Getting `mvn test` running in CI would be a worthwhile separate change.

`WindowsArguments` and its tests have no JavaFX dependency, so they compile and run standalone even where the GUI build does not.

## Verification

Unit assertions on the quoting algorithm, plus the real-process round trip, run on four JVMs:

| JVM | why it matters | result |
|---|---|---|
| Oracle JRE 8 (1.8.0_291) | source builds run the launcher here | 7/7 pass |
| OpenJDK 17.0.6 | the runtime the launcher ships with | 7/7 pass |
| OpenJDK 18 | — | 7/7 pass; control run mangles 7 |
| OpenJDK 21 | the environment reported in #33 | 7/7 pass; control run mangles 7 |

`ProcessLauncher` also still compiles clean at `--release 8`, matching the pom.

Manually confirmed end to end as well: a BridgeLink user with a quote in their password now logs in from the launcher, where previously the Administrator rejected the credentials.

## Review feedback (second commit)

Copilot raised two points; both are addressed in `bf29a4d`, which is why this PR has a second commit touching code outside the quoting fix:

- **The password was being written to stdout.** `ProcessLauncher` logs the fully assembled command line, and the password is the last argument on it. The per-argument loop is gated behind the `DEBUG` flag, but the `DEBUG: Executing command:` line was not — so it ran on every launch. Logging now happens from a copy with the password argument replaced by `********`, with the index captured when the argument is appended rather than matched back out of the list afterwards.

  This closes the *logging* leak only. The password is still on the child process command line, where any local user can read it via `wmic process get commandline`. That is the more serious exposure, it is pre-existing, and fixing it means getting the credential off argv entirely — tracked as Innovar-Healthcare/BridgeLink#184 rather than expanded into this PR.

- **The round-trip test built the JVM path as `java` rather than `java.exe`.** It passed either way because `CreateProcess` appends the extension, but it now matches `JavaConfig#getJavaHomeBuilder`.

## Provenance

All of the work in this PR — investigation, code, tests and this description — was produced by an AI agent, then reviewed and independently tested by a human before submission. The end-to-end verification against a live BridgeLink server was performed by the human reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
